### PR TITLE
disable chunking/compression for empty datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
   + module load python
   + conda init `   <--- run this only when first time use of conda`
   + conda env remove --name h5pyenv `   <--- delete conda environment h5pyenv if exists`
-  + conda create --name h5pyenv
-  + conda activate h5pyenv
+  + conda create --name h5pyenv python=3.8 `    <--- install under user's home folder`
+    * conda activate h5pyenv
+  + conda create --prefix /global/common/software/myproject/h5pyenv python=3.8 `    <--- install under Cori global common folder`
+    * conda activate /global/common/software/myproject/h5pyenv
+    * replace 'myproject' in the above 2 commands with your project ID
   + module swap PrgEnv-intel PrgEnv-gnu
   + conda install -c defaults --override-channels numpy
   + setenv MPICC "cc -shared" `   <--- for bash, export MPICC="cc -shared"`

--- a/README.md
+++ b/README.md
@@ -3,25 +3,27 @@
 ### Set up python environment
 * On Cori at NERSC
   + module load python
-  + conda init `   <--- run this only when first time use of conda`
-  + conda env remove --name h5pyenv `   <--- delete conda environment h5pyenv if exists`
-  + conda create --name h5pyenv python=3.8 `    <--- install under user's home folder`
+  + conda init `<--- run this only when first time use of conda`
+  + To install under user's home folder:
+    * conda env remove --name h5pyenv
+    * conda create --name h5pyenv python=3.8
     * conda activate h5pyenv
-  + conda create --prefix /global/common/software/myproject/h5pyenv python=3.8 `    <--- install under Cori global common folder`
+  + To install under Cori global common project folder:
+    * conda remove --name --name /global/common/software/myproject/h5pyenv
+    * conda create --prefix /global/common/software/myproject/h5pyenv python=3.8
     * conda activate /global/common/software/myproject/h5pyenv
-    * replace 'myproject' in the above 2 commands with your project ID
+    * (replace 'myproject' in the above 3 commands with your project ID)
   + module swap PrgEnv-intel PrgEnv-gnu
-  + conda install -c defaults --override-channels numpy
-  + setenv MPICC "cc -shared" `   <--- for bash, export MPICC="cc -shared"`
-  + pip install --no-binary=mpi4py mpi4py
-  + setenv CC cc  `   <--- for bash, export CC=cc`
-  + setenv HDF5_MPI ON  `   <--- for bash, export HDF5_MPI=ON`
+  + setenv MPICC "cc -shared" `<--- for bash, export MPICC="cc -shared"`
+  + pip install --force --no-cache-dir --no-binary=mpi4py mpi4py
+  + setenv CC cc  `<--- for bash, export CC=cc`
+  + setenv HDF5_MPI ON  `<--- for bash, export HDF5_MPI=ON`
   + module load cray-hdf5-parallel
-  + pip install --no-deps --no-binary=h5py h5py
-  + pip install torch
-  + pip install torch-scatter torch-sparse torch-geometric
-  + pip install particle
-  + pip list  `   <--- to show the installed packages`
+  + pip install --force --no-cache-dir --no-deps --no-binary=h5py h5py
+  + pip install --force --no-cache-dir torch
+  + pip install --force --no-cache-dir torch-scatter torch-sparse torch-geometric
+  + pip install --force --no-cache-dir particle
+  + pip list  `<--- to show the installed packages`
   + See more information in [Python User Guide](https://docs.nersc.gov/development/languages/python/nersc-python) and [Parallelism in Python](https://docs.nersc.gov/development/languages/python/parallel-python) at NERSC.
 
 * On a local Linux machine
@@ -41,10 +43,8 @@
   + pip install pandas
   + pip install boost_histogram
   + pip install torch
-  + pip install numpy
-  + pip install torch-scatter
-  + pip install torch-sparse
-  + pip install torch-geometric
+  + pip install torch-scatter torch-sparse torch-geometric
+  + pip install particle
 
 ### Run commands
 * On Cori at NERSC

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   + pip install --no-deps --no-binary=h5py h5py
   + pip install torch
   + pip install torch-scatter torch-sparse torch-geometric
+  + pip install particle
   + pip list  `   <--- to show the installed packages`
   + See more information in [Python User Guide](https://docs.nersc.gov/development/languages/python/nersc-python) and [Parallelism in Python](https://docs.nersc.gov/development/languages/python/parallel-python) at NERSC.
 

--- a/numl/core/out.py
+++ b/numl/core/out.py
@@ -31,12 +31,16 @@ class H5Out:
   def save(self, obj, name):
     for key, val in obj:
       # set chunk sizes to val shape, so there is only one chunk per dataset
-      if (isinstance(val, torch.Tensor)) :
+      # if isinstance(val, torch.Tensor) and val.nelement() == 0 :
+      #   print("zero val ",name,"/",key," shape=",val.shape)
+      if isinstance(val, torch.Tensor) and val.nelement() > 0 :
+        # Note compressed datasets can only be read/written in MPI collective I/O mode in HDF5
         self.f.create_dataset(f"/{name}/{key}", data=val, chunks=val.shape, compression="gzip")
+        # The line below is to not enable chunking/compression
+        # self.f.create_dataset(f"/{name}/{key}", data=val)
       else:
+        # if data is not a tensor or is empty, then disable chunking/compression
         self.f.create_dataset(f"/{name}/{key}", data=val)
-      # below is to disable data compression (and chunking)
-      # self.f.create_dataset(f"/{name}/{key}", data=val)
 
   def __del__(self):
     self.f.close()


### PR DESCRIPTION
Without this PR, I got the following 5 graphs with shape [2, 0]
and thus the program failed. This PR disables chunking for those
datasets with zero elements.
```
r7004_sr1311_evt65598 / edge_index_3d_u  shape= torch.Size([2, 0])
r7006_sr285_evt14273  / edge_index_3d_u  shape= torch.Size([2, 0])
r7049_sr1079_evt53995 / edge_index_3d_u  shape= torch.Size([2, 0])
r7001_sr451_evt22595  / edge_index_3d_v  shape= torch.Size([2, 0])
r7023_sr1870_evt93510 / edge_index_3d_u  shape= torch.Size([2, 0])
```