### PR TITLE
Use a better event assignment method suggested by @jrexliao

### DIFF
--- a/example/process.py
+++ b/example/process.py
@@ -4,20 +4,21 @@ import numl, glob
 import getopt
 
 def main(argv):
-  profiling  = False
-  use_seq    = False
-  inputfile  = ""
-  outputfile = ""
-  output_h5  = False
-  overwrite  = False
+  profiling    = False
+  use_seq      = False
+  inputfile    = ""
+  outputfile   = ""
+  output_h5    = False
+  overwrite    = False
+  use_evt_num  = True
   try:
-    opts, args = getopt.getopt(argv,"hpsf5i:o:",["ifile=","ofile="])
+    opts, args = getopt.getopt(argv,"hpsdf5i:o:",["ifile=","ofile="])
   except getopt.GetoptError:
-    print("Usage: process.py [-p|-s|-f|-5] -i <inputfile> -o <outputfile>")
+    print("Usage: process.py [-p|-s|-d|-f|-5] -i <inputfile> -o <outputfile>")
     sys.exit(2)
   for opt, arg in opts:
     if opt == "-h":
-      print("Usage: process.py [-p|-s|-f|-5] -i <inputfile> -o <outputfile>")
+      print("Usage: process.py [-p|-s|-d|-f|-5] -i <inputfile> -o <outputfile>")
       sys.exit()
     elif opt in ("-i", "--ifile"):  # input file name
       inputfile = arg
@@ -31,9 +32,11 @@ def main(argv):
       use_seq = True
     elif opt == "-f":   # overwrite the output file, if exists
       overwrite = True
+    elif opt == "-d":   # use event ID based data partitioning strategy
+      use_evt_num = False
 
   if inputfile == "" or outputfile == "":
-    print("Usage: process.py [-p|-s|-f|-5] -i <inputfile> -o <outputfile>")
+    print("Usage: process.py [-p|-s|-d|-f|-5] -i <inputfile> -o <outputfile>")
     sys.exit(2)
 
   if output_h5:
@@ -43,7 +46,11 @@ def main(argv):
     # output pytorch files, one graph per file
     out = numl.core.out.PTOut(outputfile)
 
-  numl.process.hitgraph.process_file(out, inputfile, l=numl.labels.standard.panoptic_label, use_seq=use_seq, profile=profiling, overwrite=overwrite)
+  numl.process.hitgraph.process_file(out, inputfile,
+                                     l=numl.labels.standard.panoptic_label,
+                                     use_seq=use_seq,
+                                     use_evt_num_based=use_evt_num,
+                                     profile=profiling)
 
 if __name__ == "__main__":
    main(sys.argv[1:])

--- a/numl/core/out.py
+++ b/numl/core/out.py
@@ -35,6 +35,8 @@ class H5Out:
         MPI.COMM_WORLD.Abort(1)
     # open/create the HDF5 file
     self.f = h5py.File(self.fname, "w")
+    # print(f"{rank}: creating {self.fname}")
+    # sys.stdout.flush()
 
   def save(self, obj, name):
     for key, val in obj:

--- a/numl/process/hitgraph.py
+++ b/numl/process/hitgraph.py
@@ -202,7 +202,7 @@ def process_event(event_id, evt, l, e, lower_bnd=20, **edge_args):
   return [[f"r{event_id[0]}_sr{event_id[1]}_evt{event_id[2]}", tg.data.Data(**data)]]
 
 def process_file(out, fname, g=process_event, l=standard.semantic_label,
-  e=edges.delaunay, p=None, use_seq=False, profile=False, overwrite=False):
+  e=edges.delaunay, p=None, use_seq=False, use_evt_num_based=True, profile=False):
 
   comm = MPI.COMM_WORLD
   nprocs = comm.Get_size()
@@ -225,6 +225,11 @@ def process_file(out, fname, g=process_event, l=standard.semantic_label,
   # open input file and read dataset "/event_table/event_id.seq_cnt"
   f = NuMLFile(fname)
 
+  if profiling:
+    open_time = MPI.Wtime() - timing
+    comm.Barrier()
+    timing = MPI.Wtime()
+
   # only use the following groups and datasets in them
   f.add_group("hit_table")
   f.add_group("particle_table", ["g4_id", "parent_id", "type", "momentum", "start_process", "end_process"])
@@ -234,35 +239,36 @@ def process_file(out, fname, g=process_event, l=standard.semantic_label,
   # number of unique event IDs in the input file
   event_id_len = len(f)
 
-  # Calculate the start and end evt.seq id for each process
-  starts = []
-  ends = []
-  _count = event_id_len // nprocs
-  for j in range(event_id_len % nprocs):
-    starts.append(_count * j + j)
-    ends.append(starts[j] + _count)
+  # Calculate the start indices and counts of evt.seq assigned to each process
+  # Note starts and counts are matter only in root process.
+  # use_seq: True  - use event.seq dataset to calculate starts and counts
+  #          False - use event.seq_cnt dataset to calculate starts and counts
+  # evt_num_based: True  - partition event numbers among all processes
+  #                False - partition event IDs among all processes
+  # starts: a numpy array of size nprocs
+  # counts: a numpy array of size nprocs
+  starts, counts = f.data_partition(use_seq=use_seq, evt_num_based=use_evt_num_based)
 
-  for j in range(event_id_len % nprocs, nprocs):
-    starts.append(_count * j + event_id_len % nprocs)
-    ends.append(starts[j] + _count - 1)
+  if profiling:
+    part_time = MPI.Wtime() - timing
+    comm.Barrier()
+    timing = MPI.Wtime()
 
-  # This process is assigned event IDs of range from my_start to my_end
-  my_start = starts[rank]
-  my_end   = ends[rank]
-  # print("rank ",rank," my_start=",my_start," my_end=",my_end)
-
-  # read data of the event IDs assigned to this process
-  f.read_data(starts, ends, use_seq=use_seq, profile=profiling)
+  # Read all data associated with event IDs assigned to this process
+  # Data read is stored as a python nested dictionary, f._data. Keys are group
+  # names, values are python dictionaries, each has names of dataset in that
+  # group as keys, and values storing dataset subarrays
+  f.read_data(starts, counts, profile=profiling)
 
   if profiling:
     read_time = MPI.Wtime() - timing
     comm.Barrier()
     timing = MPI.Wtime()
 
-  # organize the data into a list based on event IDs, so data corresponding to
-  # one event ID can be used to create a graph. A graph will be stored as a
-  # dataframe.
-  evt_list = f.build_evt(my_start, my_end)
+  # organize the assigned event data into a python list, so data corresponding
+  # to one event ID can be used to create a graph. A graph will be stored as a
+  # Pandas dataframe.
+  evt_list = f.build_evt()
   # print("len(evt_list)=", len(evt_list))
 
   if profiling:
@@ -343,10 +349,10 @@ def process_file(out, fname, g=process_event, l=standard.semantic_label,
 
     global edep1_t, edep2_t, hit_merge_t, torch_t, plane_t, label_t, edge_t
 
-    total_t = np.array([read_time, build_list_time, graph_time, write_time, total_time, edep1_t, edep2_t, label_t, hit_merge_t, plane_t, torch_t, edge_t])
-    max_total_t = np.zeros(12)
+    total_t = np.array([open_time, part_time, read_time, build_list_time, graph_time, write_time, total_time, edep1_t, edep2_t, label_t, hit_merge_t, plane_t, torch_t, edge_t])
+    max_total_t = np.zeros(14)
     comm.Reduce(total_t, max_total_t, op=MPI.MAX, root=0)
-    min_total_t = np.zeros(12)
+    min_total_t = np.zeros(14)
     comm.Reduce(total_t, min_total_t, op=MPI.MIN, root=0)
 
     local_counts  = np.empty(6, dtype=np.int64)
@@ -392,39 +398,47 @@ def process_file(out, fname, g=process_event, l=standard.semantic_label,
 
     if rank == 0:
       print("---- Timing break down of graph creation phase (in seconds) ------")
-      print("edep grouping               time MAX=%8.2f  MIN=%8.2f" % (max_total_t[5], min_total_t[5]))
-      print("edep merge                  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[6], min_total_t[6]))
+      print("edep grouping               time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
+      print("edep merge                  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[8], min_total_t[8]))
       if l == numl.labels.standard.panoptic_label:
-        print("labelling standard          time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
+        print("labelling standard          time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
       elif l == numl.labels.standard.semantic_label:
-        print("labelling standard semantic time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
+        print("labelling standard semantic time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
       elif l == numl.labels.standard.instance_label:
-        print("labelling standard instance time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
+        print("labelling standard instance time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
       elif l == numl.labels.ccqe.semantic_label:
-        print("labelling ccqe semantic     time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
+        print("labelling ccqe semantic     time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
       elif l == numl.labels.ccqe.edge_label:
-        print("labelling ccqe              time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
+        print("labelling ccqe              time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
       else:
-        print("labelling                   time MAX=%8.2f  MIN=%8.2f" % (max_total_t[7], min_total_t[7]))
-      print("hit_table merge             time MAX=%8.2f  MIN=%8.2f" % (max_total_t[8], min_total_t[8]))
-      print("plane build                 time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
-      print("torch_geometric             time MAX=%8.2f  MIN=%8.2f" % (max_total_t[10], min_total_t[10]))
+        print("labelling                   time MAX=%8.2f  MIN=%8.2f" % (max_total_t[9], min_total_t[9]))
+      print("hit_table merge             time MAX=%8.2f  MIN=%8.2f" % (max_total_t[10], min_total_t[10]))
+      print("plane build                 time MAX=%8.2f  MIN=%8.2f" % (max_total_t[11], min_total_t[11]))
+      print("torch_geometric             time MAX=%8.2f  MIN=%8.2f" % (max_total_t[12], min_total_t[12]))
       if e == numl.graph.edges.delaunay:
-        print("edge indexing delaunay      time MAX=%8.2f  MIN=%8.2f" % (max_total_t[11], min_total_t[11]))
+        print("edge indexing delaunay      time MAX=%8.2f  MIN=%8.2f" % (max_total_t[13], min_total_t[13]))
       elif e == numl.graph.edges.radius:
-        print("edge indexing radius        time MAX=%8.2f  MIN=%8.2f" % (max_total_t[11], min_total_t[11]))
+        print("edge indexing radius        time MAX=%8.2f  MIN=%8.2f" % (max_total_t[13], min_total_t[13]))
       elif e == numl.graph.edges.knn:
-        print("edge indexing knn           time MAX=%8.2f  MIN=%8.2f" % (max_total_t[11], min_total_t[11]))
+        print("edge indexing knn           time MAX=%8.2f  MIN=%8.2f" % (max_total_t[13], min_total_t[13]))
       elif e == numl.graph.edges.window:
-        print("edge indexing window        time MAX=%8.2f  MIN=%8.2f" % (max_total_t[11], min_total_t[11]))
+        print("edge indexing window        time MAX=%8.2f  MIN=%8.2f" % (max_total_t[13], min_total_t[13]))
       else:
-        print("edge indexing               time MAX=%8.2f  MIN=%8.2f" % (max_total_t[11], min_total_t[11]))
+        print("edge indexing               time MAX=%8.2f  MIN=%8.2f" % (max_total_t[13], min_total_t[13]))
       print("(MAX and MIN timings are among %d processes)" % nprocs)
       print("------------------------------------------------------------------")
       print("Number of MPI processes          =%8d" % nprocs)
       print("Total no. event IDs              =%8d" % event_id_len)
       print("Total no. non-empty events       =%8d" % num_evts)
       print("Size of all events               =%10.1f MiB" % (evt_size_sum/1048576.0))
+      if use_evt_num_based:
+        print("== Use event data amount based data partitioning strategy ==")
+      else:
+        print("== Use event ID based data partitioning strategy ==")
+      if use_seq:
+        print("== Use dataset 'event_id.seq' to calculate data partitioning ==")
+      else:
+        print("== Use dataset 'event_id.seq_cnt' to calculate data partitioning ==")
       print("Local no. events assigned     MAX=%8d   MIN=%8d   AVG=%10.1f" % (num_evts_max, num_evts_min,num_evts/nprocs))
       print("Local indiv event size in KiB MAX=%10.1f MIN=%10.1f AVG=%10.1f" % (evt_size_max/1024.0, evt_size_min/1024.0, evt_size_sum/1024.0/num_evts))
       print("Local sum   event size in MiB MAX=%10.1f MIN=%10.1f AVG=%10.1f" % (evt_size_sum_max/1048576.0, evt_size_sum_min/1048576.0, evt_size_sum/1048576.0/nprocs))
@@ -437,9 +451,11 @@ def process_file(out, fname, g=process_event, l=standard.semantic_label,
       print("(MAX and MIN timings are among %d processes)" % nprocs)
 
       print("---- Top-level timing breakdown (in seconds) ---------------------")
-      print("read from file  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[0], min_total_t[0]))
-      print("build dataframe time MAX=%8.2f  MIN=%8.2f" % (max_total_t[1], min_total_t[1]))
-      print("graph creation  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[2], min_total_t[2]))
-      print("write to files  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[3], min_total_t[3]))
-      print("total           time MAX=%8.2f  MIN=%8.2f" % (max_total_t[4], min_total_t[4]))
+      print("file open       time MAX=%8.2f  MIN=%8.2f" % (max_total_t[0], min_total_t[0]))
+      print("event partition time MAX=%8.2f  MIN=%8.2f" % (max_total_t[1], min_total_t[1]))
+      print("read from file  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[2], min_total_t[2]))
+      print("build dataframe time MAX=%8.2f  MIN=%8.2f" % (max_total_t[3], min_total_t[3]))
+      print("graph creation  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[4], min_total_t[4]))
+      print("write to files  time MAX=%8.2f  MIN=%8.2f" % (max_total_t[5], min_total_t[5]))
+      print("total           time MAX=%8.2f  MIN=%8.2f" % (max_total_t[6], min_total_t[6]))
       print("(MAX and MIN timings are among %d processes)" % nprocs)

--- a/numl/process/vis.ipynb
+++ b/numl/process/vis.ipynb
@@ -48,7 +48,7 @@
     "f.add_group(\"particle_table\", [\"g4_id\", \"parent_id\", \"type\", \"momentum\", \"start_process\", \"end_process\"])\n",
     "f.add_group(\"edep_table\")\n",
     "f.add_group(\"spacepoint_table\")\n",
-    "f.read_data([0], [1000], use_seq=True, profile=False)\n",
+    "f.read_data([0], [1000], profile=False)\n",
     "evt_list = f.build_evt(0, 1000)"
    ]
   },


### PR DESCRIPTION
* First cut the amount of boundary event into two halves based on the
  average event amount boundary line.
* The first half is used to consider assigning the boundary event to
  process i and the second half process i+1
* The boundary event will be assigned to the process i or i+1 whoever
  has the bigger half.
* Add command-line option -d to use event ID based data partitioning.
  The default is to use event number based partitioning, i.e. numbers
  of rows per event.
* Fix when some processes have no event ID assigned
* add timers for file open and data partition calculation